### PR TITLE
chore(memory): session handoff after PR #25 merge

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Normalize line endings to LF on commit, regardless of OS
+* text=auto eol=lf
+
+# Binary files — do not modify
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.avif binary
+*.gif binary
+*.pdf binary
+*.skill binary

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@ references/*.pdf
 # OS files
 .DS_Store
 Thumbs.db
+
+# Temporary/build artifacts
+*.skill
+pr-body.txt
+
+# Claude Desktop session files
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,13 +146,16 @@ Khi BẮT ĐẦU session mới:
 
 | Key | Value |
 |-----|-------|
-| Active branch | `fix-haproxy-readme-audit` |
+| Active branch | `master` (clean) |
 | Base version | HAProxy 2.0 on Ubuntu 20.04 (Canonical repo) |
 | Parts completed | Part 1 only |
 | Parts total | 29 (6 Blocks) |
-| Last commit | `bdbff8f` — fix knowledge dependency map |
-| Pending push | `git push origin fix-haproxy-readme-audit` |
-| Pending PR | Chưa tạo PR cho branch `fix-haproxy-readme-audit` |
+| Last merged PR | PR #25 — `f3256f9` (squash merge vào master 2026-03-30) |
+| Pending push | Không |
+| Pending PR | Không |
+| Linux FD doc | `linux-onboard/file-descriptor-deep-dive.md` — 791 lines, 5 SVG figures |
+| SVG audit infra | Rule 8 (document-design), svg-caption-consistency.py, Tầng 5 dependency map |
+| Installed skill | `document-design.skill` — đã cài Rule 8 (SVG-Caption Atomic Consistency) |
 
 ## Skill Quick Reference
 

--- a/memory/file-dependency-map.md
+++ b/memory/file-dependency-map.md
@@ -21,6 +21,7 @@
 | File | Nội dung chính | Related Files — PHẢI kiểm tra khi sửa |
 |------|---------------|---------------------------------------|
 | `haproxy-onboard/1.0 - haproxy-history-and-architecture.md` | Part 1: history, architecture, process model | `haproxy-onboard/README.md` (TOC entry, dependency graph), `README.md` (root — summary), `references/haproxy-version-evolution.md` (nếu có version-specific content) |
+| `linux-onboard/file-descriptor-deep-dive.md` | FD deep-dive: TLPI 3-table, epoll, CLOEXEC (791 lines) | 5 SVGs trong `images/fd-*.svg` (Tầng 5), `README.md` (root — nếu có link) |
 
 > **Template cho Parts mới:** Copy dòng trên và điều chỉnh. Mỗi Part mới phải được thêm vào bảng này.
 
@@ -44,7 +45,9 @@
 |------|---------------|---------------------------------------|
 | `images/fd-kernel-3-table-model.svg` | Figure 1-1: TLPI Three-Table Model (pure, no fork/exec) | `linux-onboard/file-descriptor-deep-dive.md` (caption tại line ~140, Exam Prep table ~738) |
 | `images/fd-fork-exec-cloexec.svg` | Figure 1-1b: fork()+exec() extension, HAProxy CLOEXEC scenario | `linux-onboard/file-descriptor-deep-dive.md` (caption tại section 1.10 ~598, Exam Prep table ~739) |
-| `images/fd-leak-and-cloexec.svg` | Figure 1-4: FD leak comparison (with/without CLOEXEC) | `linux-onboard/file-descriptor-deep-dive.md` (caption tại section 1.10 ~604) |
+| `images/fd-epoll-architecture.svg` | Figure 1-2: Kiến trúc epoll — Interest List, Ready List, Kernel Callback | `linux-onboard/file-descriptor-deep-dive.md` (caption tại line ~398, Exam Prep table ~743) |
+| `images/fd-select-poll-vs-epoll.svg` | Figure 1-3: So sánh select(), poll() và epoll | `linux-onboard/file-descriptor-deep-dive.md` (caption tại line ~414, Exam Prep table ~744) |
+| `images/fd-leak-and-cloexec.svg` | Figure 1-4: FD leak comparison (with/without CLOEXEC) | `linux-onboard/file-descriptor-deep-dive.md` (caption tại section 1.10 ~604, Exam Prep table ~747) |
 
 > **Quy tắc Tầng 5 (document-design Rule 8):** Khi sửa SVG, PHẢI đọc và update caption trong CÙNG batch thao tác. KHÔNG được giao SVG mà chưa verify caption. Chạy `svg-caption-consistency.py` trước commit.
 

--- a/memory/session-log.md
+++ b/memory/session-log.md
@@ -7,60 +7,79 @@
 
 ## Session gần nhất
 
-**Ngày:** 2026-03-29
-**Branch:** `fix-haproxy-readme-audit`
-**Base:** `main`
+**Ngày:** 2026-03-30
+**Branch:** `master` (sau khi merge PR #25)
+**Base:** `master`
 
 ### Đã hoàn thành
 
-1. **Commit `3d82766`** — fix(haproxy): correct factual errors and add missing dependency in README TOC
-   - Sửa lỗi factual trong Part 1 và bổ sung dependency thiếu trong TOC
+1. **PR #25 merged** — feat: add Linux FD deep-dive, HAProxy Part 1 restructure, and SVG audit infrastructure
+   - Squash merge commit: `f3256f9`
+   - 9 commits gộp thành 1
 
-2. **Commit `10c3a17`** — docs(haproxy): add document-design structure and fix cross-references in Part 1
-   - Áp dụng document-design skill vào Part 1 (header block, learning objectives, Bloom's Taxonomy)
+2. **Linux FD Deep-Dive** (`linux-onboard/file-descriptor-deep-dive.md`)
+   - 791 dòng, TLPI Section 5.4 three-table model
+   - Các chủ đề: FD table, Open File Table, i-node table, dup(), fork(), exec(), CLOEXEC, epoll
+   - 5 SVG figures: fd-kernel-3-table-model, fd-fork-exec-cloexec, fd-epoll-architecture, fd-select-poll-vs-epoll, fd-leak-and-cloexec
 
-3. **Commit `3535f14`** — fix(haproxy): update version refs to HAProxy 2.0 and enhance Part 1 with professor-style review
-   - Sửa version references 3.2 → 2.0 ở CẢ parent README và haproxy-onboard README
-   - 6 cải tiến professor-style cho Part 1 (context paragraph, SO_REUSEPORT, misconception box, LVS/IPVS link, forward references, production readiness)
-   - 12 technical claims fact-checked (all passed)
-   - 9 URLs verified (all HTTP 200)
+3. **SVG Audit Infrastructure** (tạo mới sau khi phát hiện SVG-caption inconsistency)
+   - Root cause analysis: SVG rewritten nhưng caption không update
+   - Tạo document-design Rule 8: SVG-Caption Atomic Consistency
+   - Tạo `svg-caption-consistency.py` (entity extraction + mismatch detection)
+   - Tạo Tầng 5 trong `memory/file-dependency-map.md` (image→markdown mapping)
+   - Cập nhật Checklist B (§5b, §6b) và Checklist C (§5a, §5b) trong CLAUDE.md
+   - Đã cài `document-design.skill` vào Claude Desktop
 
-4. **Commit `919341b`** — feat(haproxy): add version evolution tracker for cross-version changes
-   - Tạo `haproxy-onboard/references/haproxy-version-evolution.md` (52 entries, 12 categories)
-   - Thêm section Version Evolution Tracker vào `haproxy-onboard/README.md`
-   - Thiết lập inline annotation convention: `> **Lưu ý phiên bản:**`
-
-5. **Commit `bdbff8f`** — fix(haproxy): update knowledge dependency map with 7 corrected edges
-   - Sửa Mermaid dependency graph: bỏ P7→P19, thêm P8→P19, P4→P17, P6→P24, P5→P27, P25/P26/P27→P28, P1→P29
-   - Cập nhật reading path description
+4. **HAProxy Part 1 restructure** (từ session trước, included trong PR #25)
+   - Professor-style review, version correction 3.2→2.0
+   - 52-entry version evolution tracker
+   - Knowledge dependency map fixes (7 edges)
 
 ### Chưa hoàn thành (Pending)
 
-- [ ] **Push branch**: `git push origin fix-haproxy-readme-audit` (sandbox không có GitHub auth, user cần chạy trên local)
-- [ ] **Tạo PR** cho branch `fix-haproxy-readme-audit` → merge vào main
-- [ ] **File untracked**: `references/` ở repo root chứa "The Linux Programming Interface.pdf" — chưa được track (file lớn, cân nhắc .gitignore)
-- [ ] **Animation file**: `context-switching-animation.html` — untracked, chưa reference từ Part 1
-- [ ] **Tạo CLAUDE.md + memory system** — đang thực hiện trong session này
-- [ ] **Tạo quality-gate skill** — đang thực hiện trong session này
+- [ ] **HAProxy Parts 2-29**: Chưa bắt đầu (28/29 remaining)
+- [ ] **Linux FD doc — thêm sections**: Có thể mở rộng thêm về epoll edge-triggered, signalfd, eventfd
+- [ ] **Cleanup**: `document-design.skill` và `pr-body.txt` trong repo root (untracked, nên xóa)
+- [ ] **references/ folder**: Chứa "The Linux Programming Interface.pdf" — chưa track (file lớn, cân nhắc .gitignore hoặc Git LFS)
 
 ### Git State khi kết thúc
 
 ```
-Branch: fix-haproxy-readme-audit
-Status: clean (sau commit bdbff8f) + đang tạo CLAUDE.md và memory/
-Commits ahead of main: 5
-Remote push: CHƯA push (cần chạy trên local)
+Branch: master
+Status: clean (tại f3256f9)
+Remote: up to date with origin/master
+Untracked files: .claude/, document-design.skill, pr-body.txt (tạm, không cần commit)
 ```
 
 ### Lệnh cần chạy trên local
 
 ```bash
-cd network-onboard
-git push origin fix-haproxy-readme-audit
+# Không có lệnh pending — master đã push và PR đã merge
+# Nếu muốn cleanup:
+rm document-design.skill pr-body.txt
 ```
+
+### Bài học rút ra từ session này
+
+1. **SVG-caption phải sửa atomic**: Khi rewrite SVG, caption PHẢI update ngay trong cùng thao tác
+2. **Root cause trước fix**: User yêu cầu đúng — điều tra nguyên nhân → tạo prevention → rồi mới fix
+3. **PowerShell không hỗ trợ heredoc**: Dùng `--body-file` thay vì `--body` khi tạo PR từ PowerShell/VSCode terminal
+4. **CRLF vs LF**: Windows tạo CRLF, git cần LF — cân nhắc `.gitattributes` để auto-normalize
 
 ---
 
 ## Lịch sử sessions trước
 
-_(Thêm entry mới ở trên, đẩy entry cũ xuống đây. Giữ tối đa 5 entries.)_
+### Session 2026-03-29
+
+**Branch:** `fix-haproxy-readme-audit`
+
+**Đã hoàn thành:**
+1. Commit `3d82766` — fix(haproxy): correct factual errors and add missing dependency in README TOC
+2. Commit `10c3a17` — docs(haproxy): add document-design structure and fix cross-references in Part 1
+3. Commit `3535f14` — fix(haproxy): update version refs to HAProxy 2.0 and enhance Part 1 with professor-style review
+4. Commit `919341b` — feat(haproxy): add version evolution tracker for cross-version changes
+5. Commit `bdbff8f` — fix(haproxy): update knowledge dependency map with 7 corrected edges
+6. Tạo CLAUDE.md + memory system
+
+_(Giữ tối đa 5 entries.)_


### PR DESCRIPTION
## Summary

- Update CLAUDE.md Current State to reflect PR #25 merged into master
- Write full session log (2026-03-30) with lessons learned for next session handoff
- Fix file-dependency-map.md: add 2 missing SVGs (fd-epoll-architecture, fd-select-poll-vs-epoll) to Tang 5, add FD doc entry to Tang 2
- Add .gitattributes to normalize line endings (LF) and prevent CRLF diff noise on Windows
- Update .gitignore to exclude temporary artifacts (.skill, pr-body.txt, .claude/)

## Test plan

- [ ] Verify CLAUDE.md Current State matches actual repo state on master
- [ ] Verify session-log.md accurately reflects PR #25 merge and pending tasks
- [ ] Verify all 5 fd-*.svg files are listed in file-dependency-map.md Tang 5
- [ ] Verify .gitattributes normalizes line endings on next clone/checkout
