### PR TITLE
docs(linux): add real lab output for FD experiments 5-6

### DIFF
--- a/linux-onboard/file-descriptor-deep-dive.md
+++ b/linux-onboard/file-descriptor-deep-dive.md
@@ -427,43 +427,54 @@ Bạn cần Python 3 đã cài đặt, hai terminal, và `ss` command (có sẵn
 
 **Instructions:**
 
-**1.** Khởi động một web server đơn giản bằng Python:
+**1.** Đảm bảo shell chỉ có FD tiêu chuẩn trước khi bắt đầu — tránh FD còn sót từ bài thực hành trước ảnh hưởng kết quả:
 
-    [linux-node]$ python3 -m http.server 8080 &
-    [1] 5678
+    [huyvl-lab-fd]# ls /proc/$$/fd/
+    0  1  2  255
 
-**2.** Kiểm tra file descriptor của process này:
+FD 0-2 là stdin/stdout/stderr, FD 255 là FD nội bộ của bash dùng giữ script input — bình thường. Không có FD nào khác chen giữa.
 
-    [linux-node]$ ls -la /proc/5678/fd/
-    lrwx------ 1 user user 64 Mar 29 10:10 0 -> /dev/pts/0
-    lrwx------ 1 user user 64 Mar 29 10:10 1 -> /dev/pts/0
-    lrwx------ 1 user user 64 Mar 29 10:10 2 -> /dev/pts/0
-    lrwx------ 1 user user 64 Mar 29 10:10 3 -> socket:[45678]
+**2.** Khởi động một web server đơn giản bằng Python:
 
-FD 0-2 là stdin/stdout/stderr như bình thường. FD 3 là một socket — kernel hiển thị dạng `socket:[inode_number]`, trong đó số trong ngoặc vuông là i-node number của socket trong sockfs.
+    [huyvl-lab-fd]# python3 -m http.server 8080 &
+    [1] 558
+    Serving HTTP on 0.0.0.0 port 8080 (http://0.0.0.0:8080/) ...
 
-**3.** Xác nhận socket đang listen trên port 8080:
+**3.** Kiểm tra file descriptor của process này:
 
-    [linux-node]$ ss -tlnp | grep 8080
-    LISTEN  0  5  0.0.0.0:8080  0.0.0.0:*  users:(("python3",pid=5678,fd=3))
+    [huyvl-lab-fd]# ls -la /proc/558/fd/
+    total 0
+    dr-x------ 2 root root  0 Apr  3 18:42 .
+    dr-xr-xr-x 9 root root  0 Apr  3 18:42 ..
+    lrwx------ 1 root root 64 Apr  3 18:42 0 -> /dev/pts/0
+    lrwx------ 1 root root 64 Apr  3 18:42 1 -> /dev/pts/0
+    lrwx------ 1 root root 64 Apr  3 18:42 2 -> /dev/pts/0
+    lrwx------ 1 root root 64 Apr  3 18:42 3 -> 'socket:[20882]'
 
-`fd=3` trong output của `ss` xác nhận rằng listening socket chính là FD 3 mà bạn đã thấy trong `/proc`.
+FD 0-2 là stdin/stdout/stderr qua terminal `/dev/pts/0`. FD 3 là listening socket — kernel hiển thị dạng `socket:[inode_number]`, trong đó 20882 là i-node number của socket trong sockfs (pseudo-filesystem quản lý socket). Vì shell cha chỉ có FD 0-2 (đã kiểm tra ở bước 1), Python server nhận FD 3 cho listening socket — đúng quy tắc **lowest available number**.
 
-**4.** Từ một terminal khác, tạo một kết nối đến server:
+**4.** Dùng strace để quan sát syscall `accept4()` khi client kết nối. Attach strace vào process Python, chỉ theo dõi `accept4` và `close`:
 
-    [linux-node]$ curl http://localhost:8080/ &
+    [huyvl-lab-fd]# strace -e trace=accept4,close -p 558 2>&1 &
+    [2] 560
+    strace: Process 558 attached
 
-**5.** Ngay lập tức kiểm tra lại FD của Python server:
+**5.** Từ cùng terminal (hoặc terminal khác), gửi request:
 
-    [linux-node]$ ls -la /proc/5678/fd/
-    ...
-    lrwx------ 1 user user 64 Mar 29 10:10 3 -> socket:[45678]
-    lrwx------ 1 user user 64 Mar 29 10:11 4 -> socket:[45679]
+    [huyvl-lab-fd]# curl -s http://localhost:8080/ > /dev/null
+    accept4(3, {sa_family=AF_INET, sin_port=htons(45528), sin_addr=inet_addr("127.0.0.1")}, [16], SOCK_CLOEXEC) = 4
 
-FD 4 mới xuất hiện — đây là socket cho kết nối từ curl client. FD 3 vẫn là listening socket, không thay đổi. Mỗi kết nối TCP mới mà server `accept()` sẽ tạo thêm một FD mới (5, 6, 7, ...), minh họa trực tiếp tại sao số lượng FD khả dụng quyết định số kết nối đồng thời tối đa.
+`accept4(3, ...) = 4` cho biết: kernel nhận kết nối mới trên listening socket FD 3, tạo connection socket mới FD 4 cho client (port nguồn 45528). Cờ `SOCK_CLOEXEC` trong `accept4()` cho thấy Python 3 tự động đặt close-on-exec nguyên tử ngay khi tạo connection socket — đây là best practice mà mục 1.10 giải thích chi tiết: nếu process gọi `fork()+exec()` sau đó, connection socket FD 4 sẽ tự động bị đóng, ngăn FD leak.
+
+**6.** Gửi thêm request để quan sát kernel tái sử dụng FD:
+
+    [huyvl-lab-fd]# curl -s http://localhost:8080/ > /dev/null
+    accept4(3, ..., SOCK_CLOEXEC) = 4
+
+Request thứ hai cũng nhận FD 4. Lý do: sau khi phục vụ xong request đầu, Python gọi `close(4)` giải phóng connection socket. Request tiếp theo, `accept4()` lại trả FD 4 vì đó là số nhỏ nhất còn trống (FD 0-3 đều đang dùng). Đây là bằng chứng trực tiếp cho quy tắc lowest available number — kernel không "nhớ" FD cũ mà luôn cấp số nhỏ nhất khả dụng.
 
 **Finish:**
-`kill %1` để tắt Python server.
+`kill %1` để tắt Python server. `kill %2` để tắt strace.
 
 ---
 
@@ -655,30 +666,28 @@ Bạn cần `strace` đã cài đặt (`apt install strace`), Python 3, và `cur
 
 **Instructions:**
 
-**1.** Khởi động Python HTTP server với strace:
+**1.** Khởi động Python HTTP server với strace — theo dõi toàn bộ syscall liên quan vòng đời socket:
 
-    [linux-node]$ strace -e trace=socket,bind,listen,accept4,close -f python3 -m http.server 8080 2>/tmp/strace_output.txt &
+    [huyvl-lab-fd]# strace -e trace=socket,bind,listen,accept4,close -f python3 -m http.server 8080 2>/tmp/strace_output.txt &
 
-**2.** Từ terminal khác, gửi request:
+**2.** Từ terminal khác (hoặc cùng terminal), gửi request:
 
-    [linux-node]$ curl http://localhost:8080/
+    [huyvl-lab-fd]# curl -s http://localhost:8080/ > /dev/null
 
 **3.** Đọc strace output:
 
-    [linux-node]$ grep -E 'socket|bind|listen|accept' /tmp/strace_output.txt
+    [huyvl-lab-fd]# grep -E 'socket|bind|listen|accept' /tmp/strace_output.txt
 
-Output mẫu:
+Output kỳ vọng (FD number có thể khác tùy hệ thống):
 
-```
-socket(AF_INET, SOCK_STREAM, IPPROTO_TCP) = 3
-bind(3, {sa_family=AF_INET, sin_port=htons(8080), sin_addr=inet_addr("0.0.0.0")}, 16) = 0
-listen(3, 5) = 0
-accept4(3, {sa_family=AF_INET, sin_port=htons(54321), sin_addr=inet_addr("127.0.0.1")}, ...) = 4
-```
+    socket(AF_INET, SOCK_STREAM|SOCK_CLOEXEC, IPPROTO_TCP) = 4
+    bind(4, {sa_family=AF_INET, sin_port=htons(8080), sin_addr=inet_addr("0.0.0.0")}, 16) = 0
+    listen(4, 5) = 0
+    accept4(4, {sa_family=AF_INET, sin_port=htons(47968), sin_addr=inet_addr("127.0.0.1")}, [16], SOCK_CLOEXEC) = 5
 
-Chuỗi syscall thể hiện rõ vòng đời của socket: `socket()` tạo FD 3 (listening socket), `bind(3, ...)` gán địa chỉ 0.0.0.0:8080, `listen(3, 5)` chuyển sang trạng thái LISTEN với backlog = 5. Khi client kết nối, `accept4(3, ...) = 4` tạo FD 4 — đây là connection socket riêng biệt cho kết nối từ client (port 54321). FD 3 vẫn tiếp tục lắng nghe kết nối mới.
+Chuỗi syscall thể hiện rõ vòng đời của socket: `socket(SOCK_STREAM|SOCK_CLOEXEC)` tạo listening socket với close-on-exec nguyên tử, `bind()` gán địa chỉ 0.0.0.0:8080, `listen(4, 5)` chuyển sang trạng thái LISTEN với backlog = 5. Khi client kết nối, `accept4(4, ..., SOCK_CLOEXEC) = 5` tạo connection socket FD 5 — cũng với `SOCK_CLOEXEC`. Cờ này đảm bảo cả listening socket lẫn connection socket đều tự động đóng nếu process gọi `exec()`, ngăn FD leak (mục 1.10).
 
-**4.** Gửi thêm vài kết nối và quan sát FD tăng dần (5, 6, 7, ...).
+**4.** Gửi thêm vài kết nối và quan sát: FD 5 được tái sử dụng mỗi lần (vì Python close FD 5 sau mỗi request, kernel cấp lại FD 5 theo quy tắc lowest available number).
 
 **Finish:**
 Tắt server và xóa file tạm: `kill %1 && rm /tmp/strace_output.txt`
@@ -824,74 +833,99 @@ Trên OpenStack, khi Neutron agent hoặc Nova compute `fork()+exec()` các help
 
 > **Lưu ý kỹ thuật:** Trên Python 3.4+, mọi FD mới tạo bởi `open()`, `socket.socket()`, `os.pipe()` đều tự động có cờ `CLOEXEC` (PEP 446). Trên Python 2, FD mặc định KHÔNG có cờ này — đây là lý do nhiều bug FD leak xuất hiện trong các dự án OpenStack thời Python 2.
 
-### ▶ Guided Exercise: Quan sát hành vi close-on-exec
+### ▶ Guided Exercise: Chứng minh FD leak qua exec() và CLOEXEC ngăn chặn
 
-Trong bài thực hành này, bạn chứng minh rằng FD không có cờ `CLOEXEC` sẽ rò rỉ qua `exec()`, và FD có cờ `CLOEXEC` sẽ bị kernel tự động đóng.
+Bài thực hành gồm hai phần đối lập: phần A chứng minh FD **rò rỉ** qua `exec()` khi không có `CLOEXEC`, phần B chứng minh kernel **tự động đóng** FD khi có `CLOEXEC`. Kết hợp cả hai, bạn thấy rõ vai trò của cờ close-on-exec trong thực tế.
 
 **Before You Begin:**
-Bạn cần Python 3.4+ (để có `os.O_CLOEXEC`). Kiểm tra bằng `python3 -c "import os; print(hasattr(os, 'O_CLOEXEC'))"` — kết quả phải là `True`.
+Đảm bảo môi trường sạch — chỉ có FD 0, 1, 2 tiêu chuẩn. Nếu tồn tại FD thừa từ thí nghiệm trước, đóng bằng `exec N>&-` (N là số FD). Bài học từ thí nghiệm 5: FD thừa từ session trước sẽ bị process con kế thừa và làm sai lệch kết quả.
 
 **Outcomes:**
 - Thấy được FD rò rỉ sang chương trình mới sau `exec()` khi không có `CLOEXEC`
-- Xác minh FD bị đóng tự động khi có cờ `CLOEXEC`
+- Xác minh FD bị kernel tự động đóng khi có cờ `CLOEXEC`
+- Hiểu tại sao network server hiện đại (HAProxy, Nginx, Python 3) luôn đặt `CLOEXEC` trên mọi FD
 
 **Instructions:**
 
-**1.** Tạo script Python mô phỏng FD leak. Script mở một file, rồi `fork()+exec()` lệnh `ls -la /proc/self/fd/` để liệt kê FD của child:
+**Phần A — Chứng minh FD leak khi KHÔNG có CLOEXEC:**
 
-```python
-# Lưu file: /tmp/test_cloexec.py
-import os, sys
-
-# Mở file KHÔNG có O_CLOEXEC
-fd_no_cloexec = os.open("/etc/hostname", os.O_RDONLY)
-print(f"Parent: opened /etc/hostname as FD {fd_no_cloexec} (no CLOEXEC)")
-
-# Mở file CÓ O_CLOEXEC
-fd_with_cloexec = os.open("/etc/hostname", os.O_RDONLY | os.O_CLOEXEC)
-print(f"Parent: opened /etc/hostname as FD {fd_with_cloexec} (with CLOEXEC)")
-
-print(f"\nChild process FDs after exec():")
-sys.stdout.flush()
-
-pid = os.fork()
-if pid == 0:
-    # Child process — exec ls để xem FD nào còn sống
-    os.execvp("ls", ["ls", "-la", "/proc/self/fd/"])
-else:
-    os.waitpid(pid, 0)
-```
-
-**2.** Chạy script:
-
-    [linux-node]$ python3 /tmp/test_cloexec.py
-
-Output mẫu:
+**1.** Kiểm tra môi trường sạch:
 
 ```
-Parent: opened /etc/hostname as FD 3 (no CLOEXEC)
-Parent: opened /etc/hostname as FD 4 (with CLOEXEC)
-
-Child process FDs after exec():
-lr-x------ 1 user user 64 ... 0 -> /dev/pts/0
-lrwx------ 1 user user 64 ... 1 -> /dev/pts/0
-lrwx------ 1 user user 64 ... 2 -> /dev/pts/0
-lr-x------ 1 user user 64 ... 3 -> /etc/hostname
+root@huyvl-lab-fd:~# ls -l /proc/$$/fd/
+total 0
+lrwx------ 1 root root 64 Apr  3 18:41 0 -> /dev/pts/0
+lrwx------ 1 root root 64 Apr  3 18:41 1 -> /dev/pts/0
+lrwx------ 1 root root 64 Apr  3 18:41 2 -> /dev/pts/0
+lrwx------ 1 root root 64 Apr  3 18:41 255 -> /dev/pts/0
 ```
 
-FD 3 (không có `CLOEXEC`) vẫn tồn tại trong child sau `exec()` — đây chính là FD rò rỉ. FD 4 (có `CLOEXEC`) đã bị kernel tự động đóng trước khi `exec()` hoàn tất nên không xuất hiện trong output. FD 0, 1, 2 (stdin/stdout/stderr) vẫn tồn tại vì chúng cần thiết cho chương trình mới và thường không được đánh dấu CLOEXEC.
+Chỉ có FD 0, 1, 2 (stdin/stdout/stderr) và FD 255 (bash internal) — môi trường sạch, sẵn sàng thí nghiệm.
 
-**3.** Xác minh FD 3 trong child thực sự đọc được nội dung file. Sửa script, thay `os.execvp("ls", ...)` bằng:
+**2.** Mở FD 3 trỏ tới file (KHÔNG có cờ CLOEXEC):
 
-```python
-    os.execvp("python3", ["python3", "-c",
-        "import os; print('Child read from leaked FD 3:', os.read(3, 100))"])
+    root@huyvl-lab-fd:~# exec 3>/tmp/cloexec-test.txt
+
+**3.** Xác nhận FD 3 tồn tại trong shell hiện tại:
+
+```
+root@huyvl-lab-fd:~# ls -l /proc/$$/fd/3
+l-wx------ 1 root root 64 Apr  3 18:41 /proc/527/fd/3 -> /tmp/cloexec-test.txt
 ```
 
-Output sẽ hiện nội dung `/etc/hostname` — chứng minh child truy cập được file thông qua FD rò rỉ mà không cần gọi `open()`.
+Shell (PID 527) đang giữ FD 3 trỏ tới `/tmp/cloexec-test.txt` ở chế độ write-only (`l-wx`).
+
+**4.** Thực hiện `fork()+exec()` qua `bash -c` — kiểm tra FD 3 có rò rỉ sang process mới không:
+
+```
+root@huyvl-lab-fd:~# bash -c 'ls -l /proc/$$/fd/3 2>/dev/null && echo "FD 3 LEAKED — still open after exec()" || echo "FD 3 closed — no leak"'
+l-wx------ 1 root root 64 Apr  3 18:50 /proc/577/fd/3 -> /tmp/cloexec-test.txt
+FD 3 LEAKED — still open after exec()
+```
+
+Khi shell thực hiện `bash -c`, kernel gọi `fork()` tạo child process (PID 577), sau đó `exec("/bin/bash")` thay thế child bằng chương trình bash mới. Vì FD 3 **không có flag CLOEXEC**, kernel giữ nguyên nó qua `exec()`. Process mới (PID 577) — một instance bash hoàn toàn mới — vẫn thấy FD 3 trỏ tới `/tmp/cloexec-test.txt` mặc dù nó không hề mở file đó. Đây chính là **FD leak** — cùng hiện tượng đã gây lỗi `Address already in use` trong kịch bản HAProxy ở phần lý thuyết.
+
+**Phần B — Chứng minh CLOEXEC ngăn chặn leak:**
+
+**5.** Đóng FD 3 cũ và xác nhận môi trường sạch trở lại:
+
+    root@huyvl-lab-fd:~# exec 3>&-
+
+**6.** Dùng Python mở FD 3 với cờ `FD_CLOEXEC`, sau đó gọi `exec()` để kiểm tra:
+
+```
+root@huyvl-lab-fd:~# python3 -c "
+import os, fcntl
+
+fd = os.open('/tmp/cloexec-test.txt', os.O_WRONLY | os.O_CREAT, 0o644)
+print(f'os.open() returned FD: {fd}')
+
+# Chi dup2 + close khi fd KHAC 3
+if fd != 3:
+    os.dup2(fd, 3)
+    os.close(fd)
+
+# Set CLOEXEC on FD 3
+flags = fcntl.fcntl(3, fcntl.F_GETFD)
+fcntl.fcntl(3, fcntl.F_SETFD, flags | fcntl.FD_CLOEXEC)
+print('FD 3 flags before exec: FD_CLOEXEC =', bool(fcntl.fcntl(3, fcntl.F_GETFD) & fcntl.FD_CLOEXEC))
+
+os.execlp('bash', 'bash', '-c', 'ls -l /proc/\$\$/fd/3 2>/dev/null && echo \"FD 3 LEAKED\" || echo \"FD 3 closed by CLOEXEC — no leak\"')
+"
+os.open() returned FD: 3
+FD 3 flags before exec: FD_CLOEXEC = True
+FD 3 closed by CLOEXEC — no leak
+```
+
+Phân tích kết quả: `os.open()` trả về FD 3 (lowest available — quy tắc đã chứng minh ở mục 1.3). Vì `fd` đã là 3, đoạn `if fd != 3` bỏ qua `dup2()`/`close()` — tránh lỗi đóng nhầm FD vừa mở (nếu `dup2(3, 3)` thì là no-op theo POSIX, nhưng `os.close(3)` ngay sau sẽ đóng FD ta cần). Sau khi `fcntl()` đặt `FD_CLOEXEC = True`, Python gọi `os.execlp()` — kernel quét close-on-exec bitmap, thấy FD 3 có cờ CLOEXEC → **tự động đóng FD 3** trước khi chương trình mới (`bash -c`) bắt đầu thực thi. Kết quả: process mới không thấy FD 3, in ra "FD 3 closed by CLOEXEC — no leak".
+
+> **Key Topic:** Đây chính là cơ chế mà Python 3 sử dụng khi gọi `socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, 0)` — bạn đã thấy nó trong strace ở mục 1.4 khi quan sát `accept4()` với flag `SOCK_CLOEXEC`. Cờ này được đặt **nguyên tử** ngay khi FD được tạo (không qua hai bước `open()` rồi `fcntl()` như bài thực hành này), loại bỏ race condition trong chương trình multi-threaded.
+
+**Evaluation:**
+So sánh hai kết quả: phần A — FD 3 vẫn tồn tại sau `exec()` (FD leak), phần B — FD 3 bị kernel đóng trước `exec()` (no leak). Sự khác biệt duy nhất là cờ `FD_CLOEXEC` trên FD 3.
 
 **Finish:**
-Xóa file tạm: `rm /tmp/test_cloexec.py`
+Xóa file tạm: `rm /tmp/cloexec-test.txt`. Đóng FD 3 nếu còn mở: `exec 3>&-`.
 
 ---
 

--- a/linux-onboard/file-descriptor-deep-dive.md
+++ b/linux-onboard/file-descriptor-deep-dive.md
@@ -211,6 +211,181 @@ Cột NODE (262155) giống nhau ở cả hai dòng — cả hai FD trỏ đến
 **Finish:**
 Ký hiệu `3<&-` đóng FD 3. Kernel giảm reference count của open file description tương ứng. Khi count về 0, entry được giải phóng.
 
+### ▶ Guided Exercise: Quan sát file offset thay đổi qua /proc/pid/fdinfo
+
+Trong bài thực hành này, bạn nhìn trực tiếp vào bảng thứ nhất (per-process FD table) và bảng thứ hai (open file description) thông qua pseudo-filesystem `/proc`. Cụ thể, `/proc/<pid>/fdinfo/<fd>` xuất ba trường quan trọng: `pos` (file offset nằm trong open file description), `flags` (status flags), và `mnt_id` (mount point chứa file). Đây là cửa sổ duy nhất để quan sát trạng thái bên trong kernel mà không cần debugger.
+
+**Outcomes:**
+- Thấy được file offset thay đổi theo thời gian thực sau mỗi lần `read()`
+- Hiểu rằng `pos` không nằm trong FD table (bảng 1) mà nằm trong open file description (bảng 2) — FD chỉ là con trỏ đến entry đó
+
+**Before You Begin:**
+Một terminal duy nhất, quyền root hoặc user thường (quyền root cho phép xem fdinfo của mọi process).
+
+**Instructions:**
+
+**1.** Tạo file test và mở FD 3 để đọc:
+
+    [huyvl-lab-fd]# echo "ABCDEFGHIJ" > /tmp/testfile.txt
+    [huyvl-lab-fd]# exec 3< /tmp/testfile.txt
+
+**2.** Kiểm tra trạng thái ban đầu của FD 3:
+
+    [huyvl-lab-fd]# cat /proc/$$/fdinfo/3
+    pos:    0
+    flags:  0100000
+    mnt_id: 31
+
+`pos: 0` cho biết file offset đang ở đầu file — bạn vừa mở, chưa đọc byte nào. `flags: 0100000` tương ứng O_RDONLY + O_LARGEFILE (kernel tự thêm O_LARGEFILE trên hệ thống 64-bit). `mnt_id: 31` xác định mount point chứa file `/tmp/testfile.txt`.
+
+**3.** Đọc 5 bytes qua FD 3, rồi kiểm tra offset:
+
+    [huyvl-lab-fd]# read -n 5 -u 3 data
+    [huyvl-lab-fd]# echo "$data"
+    ABCDE
+    [huyvl-lab-fd]# cat /proc/$$/fdinfo/3
+    pos:    5
+    flags:  0100000
+    mnt_id: 31
+
+`pos` nhảy từ 0 lên 5 — kernel ghi nhận 5 bytes đã được đọc. Giá trị này nằm trong open file description (bảng 2), không phải trong per-process FD table (bảng 1). FD 3 chỉ là con trỏ dẫn đến entry chứa offset này.
+
+**Finish:**
+Giữ nguyên FD 3 mở — bài thực hành tiếp theo sẽ sử dụng nó để chứng minh hành vi chia sẻ offset khi `dup()`.
+
+### ▶ Guided Exercise: dup() — hai FD chia sẻ cùng một open file description
+
+Bài thực hành này chứng minh điểm then chốt nhất của mô hình 3 bảng: khi `dup()` tạo FD mới, FD mới không tạo open file description riêng mà trỏ đến **cùng entry** trong bảng thứ hai. Hệ quả trực tiếp: đọc qua FD này thì offset của FD kia cũng thay đổi — vì cả hai đang nhìn vào cùng một open file description.
+
+**Outcomes:**
+- Chứng minh hai FD có cùng `pos` ngay sau `dup()`
+- Chứng minh đọc qua FD 4 làm thay đổi `pos` của FD 3 (và ngược lại)
+- Liên hệ với cơ chế shell redirect `2>&1` (FD 2 trỏ đến cùng OFD với FD 1)
+
+**Before You Begin:**
+FD 3 từ bài trước phải còn mở với `pos: 5`. Kiểm tra: `cat /proc/$$/fdinfo/3` phải trả về `pos: 5`.
+
+**Instructions:**
+
+**1.** Tạo FD 4 bằng `dup()` từ FD 3:
+
+    [huyvl-lab-fd]# exec 4>&3
+
+Lệnh `exec 4>&3` bảo bash gọi `dup2(3, 4)` — kernel copy entry FD 3 trong per-process table sang vị trí FD 4, nhưng cả hai đều trỏ đến cùng một open file description. Trường `f_count` (reference count) trong OFD tăng từ 1 lên 2.
+
+**2.** Xác minh cả hai FD có cùng offset:
+
+    [huyvl-lab-fd]# cat /proc/$$/fdinfo/3
+    pos:    5
+    flags:  0100000
+    mnt_id: 31
+    [huyvl-lab-fd]# cat /proc/$$/fdinfo/4
+    pos:    5
+    flags:  0100000
+    mnt_id: 31
+
+Cả hai cho `pos: 5` — vì cùng trỏ đến một OFD.
+
+**3.** Đọc 3 bytes qua FD 4, rồi kiểm tra offset của FD 3 (FD mà bạn không hề đụng vào):
+
+    [huyvl-lab-fd]# read -n 3 -u 4 more
+    [huyvl-lab-fd]# echo "$more"
+    FGH
+    [huyvl-lab-fd]# cat /proc/$$/fdinfo/3
+    pos:    8
+    flags:  0100000
+    mnt_id: 31
+    [huyvl-lab-fd]# cat /proc/$$/fdinfo/4
+    pos:    8
+    flags:  0100000
+    mnt_id: 31
+
+Bạn chỉ đọc qua FD 4, nhưng `pos` của FD 3 cũng nhảy từ 5 lên 8. Đây là bằng chứng trực tiếp rằng offset không nằm trong per-process FD table (bảng 1) mà nằm trong open file description (bảng 2), và `dup()` khiến hai FD chia sẻ cùng entry đó.
+
+> **Key Topic:** `dup()` và `dup2()` tạo FD mới trỏ đến cùng open file description — nghĩa là chia sẻ file offset, status flags, và signal-driven I/O settings. Đây chính xác là cơ chế đằng sau shell redirect `2>&1`: FD 2 (stderr) được `dup()` để trỏ cùng OFD với FD 1 (stdout), nên mọi output lỗi đi cùng đích với output thường. Tuy nhiên, FD flags (cụ thể là close-on-exec) là riêng biệt — mỗi FD có cờ CLOEXEC độc lập dù trỏ cùng OFD (man dup(2), man7.org).
+
+**4.** Dọn dẹp:
+
+    [huyvl-lab-fd]# exec 3<&-
+    [huyvl-lab-fd]# exec 4<&-
+
+**Finish:**
+Đóng cả hai FD. Kernel giảm reference count của OFD mỗi lần đóng một FD. Khi FD 3 đóng, `f_count` giảm từ 2 về 1 (FD 4 vẫn giữ). Khi FD 4 đóng, `f_count` về 0 và kernel giải phóng OFD đó.
+
+### ▶ Guided Exercise: fork() — process con thừa kế FD trỏ cùng open file description
+
+Bài thực hành trước chứng minh `dup()` tạo hai FD **trong cùng process** chia sẻ OFD. Bài này đi xa hơn: `fork()` tạo process con thừa kế **toàn bộ FD table**, và các FD trong con trỏ đến **cùng các OFD** với cha. Đây là cơ chế giải thích tại sao shell pipeline hoạt động — process cha (shell) thiết lập pipe FDs, fork() process con, và con thừa kế FDs trỏ đến cùng pipe OFD.
+
+**Outcomes:**
+- Chứng minh process con có cùng FD trỏ đến cùng OFD (cùng offset) với cha
+- Chứng minh đọc trong process con làm thay đổi offset nhìn từ process cha
+- Liên hệ với cơ chế fork()+exec() trong HAProxy khi spawn health check processes
+
+**Before You Begin:**
+Một terminal duy nhất, quyền root. Bài thực hành sử dụng subshell `( ... )` thay vì `bash -c` để tránh nhiễu từ bash startup. Lý do: `bash -c '...'` thực hiện `fork()+exec()` — bash mới khởi động lại có thể đọc vài bytes trên FD kế thừa để kiểm tra nội bộ, gây lệch offset. Subshell `( ... )` chỉ thực hiện `fork()` thuần túy, không `exec()`, nên process con là bản sao chính xác của cha đã khởi tạo xong — không đụng FD.
+
+**Instructions:**
+
+**1.** Tạo file test mới và mở FD 3:
+
+    [huyvl-lab-fd]# echo "0123456789ABCDEF" > /tmp/forktest.txt
+    [huyvl-lab-fd]# exec 3< /tmp/forktest.txt
+
+**2.** Đọc 4 bytes để đưa offset lên 4:
+
+    [huyvl-lab-fd]# read -n 4 -u 3 chunk
+    [huyvl-lab-fd]# echo "$chunk"
+    0123
+    [huyvl-lab-fd]# cat /proc/$$/fdinfo/3
+    pos:    4
+    flags:  0100000
+    mnt_id: 31
+
+**3.** Kiểm tra FD 3 từ bên trong subshell (fork):
+
+    [huyvl-lab-fd]# ( cat /proc/self/fdinfo/3 )
+    pos:    4
+    flags:  0100000
+    mnt_id: 31
+
+Subshell `( ... )` fork ra process con — con thừa kế FD 3 trỏ đến cùng OFD. `/proc/self/fdinfo/3` bên trong con cho `pos: 4`, giống hệt cha — vì cả hai nhìn vào cùng một entry trong open file table.
+
+**4.** Đọc 3 bytes trong subshell, rồi kiểm tra offset từ process cha:
+
+    [huyvl-lab-fd]# ( read -n 3 -u 3 x; echo "child read: $x"; cat /proc/self/fdinfo/3 )
+    child read: 456
+    pos:    7
+    flags:  0100000
+    mnt_id: 31
+    [huyvl-lab-fd]# cat /proc/$$/fdinfo/3
+    pos:    7
+    flags:  0100000
+    mnt_id: 31
+
+Process con đọc `456` (3 bytes tiếp theo sau vị trí 4), offset tiến lên 7. Quay về process cha, `cat /proc/$$/fdinfo/3` cũng cho `pos: 7` — dù cha không hề gọi `read()` kể từ bước 2. Đây là bằng chứng trực tiếp: `fork()` khiến con thừa kế FD trỏ đến cùng open file description, và mọi thay đổi offset từ phía con đều phản ánh ngay lập tức ở phía cha.
+
+> **Key Topic:** `fork()` khiến process con thừa kế bản sao FD table — nhưng các FD trỏ đến **cùng** open file descriptions với cha (man fork(2), man7.org). Hệ quả: thay đổi offset ở bên nào cũng ảnh hưởng bên kia. Đây là lý do HAProxy và các network server cẩn thận đặt cờ `CLOEXEC` trên listening socket FDs — để khi fork()+exec() health check script, script con không vô tình thừa kế và giữ tham chiếu đến socket lắng nghe.
+
+**5.** Phân biệt chia sẻ OFD và cách ly biến — hiểu đúng ranh giới fork():
+
+Thí nghiệm vừa rồi chứng minh fork() chia sẻ OFD (offset thay đổi xuyên process). Một câu hỏi tự nhiên: nếu FD chia sẻ, vậy biến trong process con có chia sẻ với cha không? Câu trả lời là không — và sự khác biệt này chính xác phản ánh ranh giới giữa kernel space (OFD — kernel quản lý, chia sẻ qua con trỏ) và user space (biến — nằm trong address space riêng, copy-on-write sau fork).
+
+    [huyvl-lab-fd]# x="PARENT"
+    [huyvl-lab-fd]# ( x="CHILD"; echo "inside: $x" )
+    inside: CHILD
+    [huyvl-lab-fd]# echo "outside: $x"
+    outside: PARENT
+
+Process con sửa biến `x` thành `CHILD`, nhưng cha vẫn giữ `PARENT` — vì mỗi cặp ngoặc `( ... )` tạo một fork riêng biệt với address space được copy. Biến nằm trong user space (bản sao riêng), còn OFD nằm trong kernel space (con trỏ chia sẻ). Đây cũng là lý do bạn không thể tách lệnh `read` và `echo "$x"` ra hai subshell riêng biệt — biến `$x` gán trong subshell A sẽ chết theo subshell A, subshell B không thấy nó.
+
+**6.** Dọn dẹp:
+
+    [huyvl-lab-fd]# exec 3<&-
+    [huyvl-lab-fd]# rm /tmp/forktest.txt /tmp/testfile.txt
+
+**Finish:**
+Bốn bài thực hành trên đã chứng minh bằng thực nghiệm mọi khía cạnh của mô hình 3 bảng: per-process FD table (fdinfo cho mỗi FD riêng), open file description chia sẻ qua dup() và fork() (cùng offset), i-node chia sẻ qua open() độc lập (cùng NODE trong lsof), và ranh giới giữa kernel space (OFD — chia sẻ) và user space (biến — cách ly). Kiến thức này là nền tảng trực tiếp để hiểu close-on-exec (mục 1.10) và cơ chế HAProxy ngăn FD leak khi spawn process con.
+
 ---
 
 ## 1.4 - Socket là file descriptor: cầu nối với mạng máy tính

--- a/memory/session-log.md
+++ b/memory/session-log.md
@@ -7,89 +7,100 @@
 
 ## Session gần nhất
 
-**Ngày:** 2026-04-02
-**Branch:** `fix/fd-doc-audit-corrections` (clean — commit `6ecfb07`)
-**Base:** `master` tại `6573211`
+**Ngày:** 2026-04-03
+**Branch:** `master` (dirty — file-descriptor-deep-dive.md đã sửa, chưa commit)
+**Base:** `master` tại `e92ef0f`
 
 ### Đã hoàn thành
 
-1. **Full 6-phase audit của `linux-onboard/file-descriptor-deep-dive.md`** (user request: "Tài liệu về FD này đúng chứ? Hãy dừng tất cả skill để audit nó")
-   - Phase 1: Đọc toàn bộ 791 dòng, liệt kê 13 technical claims cần verify
-   - Phase 2: Fact-check 13 claims — 11 CORRECT, 2 INCORRECT (đã sửa)
-     - Sửa 1: HAProxy hybrid ET/LT (FD_ET_POSSIBLE), không phải purely LT
-     - Sửa 2: HAProxy CLOEXEC conditional (accept4 + fcntl fallback), không phải "mọi socket/open"
-   - Phase 3: Verify 11 URLs — tất cả HTTP 200
-   - Phase 4: Document-design compliance — 12 H2 sections (vượt limit 7, nhưng chấp nhận cho standalone deep-dive), 7 Key Topics, 2 Misconceptions, learning elements đầy đủ
-   - Phase 5: Professor-style compliance — 6 criteria (2.1-2.6) đạt
-   - Phase 6: Commit fix trên feature branch
+1. **Thí nghiệm 6A/6B — CLOEXEC trên huyvl-lab-fd** (tiếp nối thí nghiệm 1-5 từ session trước)
+   - 6A: `exec 3>/tmp/cloexec-test.txt` + `bash -c` → FD 3 LEAKED (PID 527→577)
+   - 6B: Python `fcntl(3, F_SETFD, FD_CLOEXEC)` + `os.execlp()` → FD 3 closed by CLOEXEC
+   - Edge case: `os.open()` trả FD 3, `dup2(3,3)` là no-op → `os.close(3)` đóng nhầm → sửa bằng `if fd != 3`
 
-2. **Thay thế lab output placeholder bằng real output** (từ session trước, chưa commit)
-   - Section 1.2 Guided Exercise: hostname `huyvl-lab-fd`, PIDs 35567/35571, `/dev/pts/2`, root user
-   - Before You Begin: cập nhật quyền user/root
-
-3. **Commit**: `6ecfb07` — `fix(linux): audit FD deep-dive — correct HAProxy claims, add real lab output`
+2. **Cập nhật `linux-onboard/file-descriptor-deep-dive.md`** (3 sections thay đổi):
+   - **Section 1.4**: Thay placeholder bằng real output từ huyvl-lab-fd (PID 558, FD 3=socket:[20882], accept4 với SOCK_CLOEXEC, FD reuse). Thêm bước 1 kiểm tra môi trường sạch, bước 6 quan sát FD reuse.
+   - **Section 1.9**: Thay placeholder strace output bằng real output (socket SOCK_CLOEXEC, accept4 SOCK_CLOEXEC).
+   - **Section 1.10 Guided Exercise**: Thay hoàn toàn exercise cũ (Python script placeholder) bằng exercise mới 2 phần (A: FD leak, B: CLOEXEC ngăn chặn) với real terminal output.
 
 ### Chưa hoàn thành (Pending)
 
-- [ ] **Push branch `fix/fd-doc-audit-corrections`** → tạo PR → merge (sandbox không có git auth)
+- [ ] **Commit + push + PR** cho thay đổi section 1.4 + 1.9 + 1.10 (sandbox bị lock file, cần chạy trên local)
+- [ ] **PR cho experiments 1-4**: Branch `feat/fd-lab-3table-experiments` đã push, PR có thể chưa tạo (GitHub API timeout session trước)
 - [ ] **HAProxy Parts 2-29**: Chưa bắt đầu (28/29 remaining)
-- [ ] **Linux FD doc — mở rộng**: epoll advanced topics, signalfd/eventfd/timerfd (user nói "thực hành nó sau")
-- [ ] **Cleanup trên local**: `git rm haproxy-onboard/references/haproxy-version-evolution.md`, xóa `document-design.skill` và `pr-body.txt` trong repo root
+- [ ] **Linux FD doc — mở rộng**: epoll advanced topics, signalfd/eventfd/timerfd
+- [ ] **Cleanup trên local**: `git rm haproxy-onboard/references/haproxy-version-evolution.md`, xóa `document-design.skill` và `pr-body.txt`
 
 ### Git State khi kết thúc
 
 ```
-Branch: fix/fd-doc-audit-corrections (clean)
-Remote: chưa push (sandbox không có git auth)
-Base: master tại 6573211
-Commit mới: 6ecfb07 — fix(linux): audit FD deep-dive
-Modified files:
-  - linux-onboard/file-descriptor-deep-dive.md (3 changes: real lab output, HAProxy ET/LT fix, HAProxy CLOEXEC fix)
+Branch: master (dirty)
+Remote: origin/master tại e92ef0f
+Modified files (chưa commit):
+  - linux-onboard/file-descriptor-deep-dive.md (sections 1.4, 1.9, 1.10 — real lab output)
+Lock files: .git/index.lock tồn tại trong sandbox — cần xóa trên local
 ```
 
 ### Lệnh cần chạy trên local
 
 ```bash
-# Pull branch và push lên GitHub
+# 0. Xóa lock file nếu tồn tại
 cd network-onboard
-git fetch origin
-git checkout fix/fd-doc-audit-corrections
-git push -u origin fix/fd-doc-audit-corrections
+rm -f .git/index.lock .git/HEAD.lock
 
-# Tạo PR
-gh pr create --base master --title "fix(linux): audit FD deep-dive — correct HAProxy claims, add real lab output" --body "## Summary
-- Full 6-phase audit of linux-onboard/file-descriptor-deep-dive.md before GitHub publication
-- Correct 2 factual errors: HAProxy hybrid ET/LT (not purely LT), HAProxy CLOEXEC conditional (not unconditional)
-- Replace placeholder lab output with real terminal output from huyvl-lab-fd
+# 1. Tạo branch mới từ master
+git checkout master
+git pull origin master
+git checkout -b feat/fd-lab-strace-cloexec
 
-## Audit Results
-- 13 technical claims fact-checked: 11 correct, 2 corrected
-- 11 reference URLs verified: all HTTP 200
-- Document-design and professor-style compliance: passed
+# 2. Commit (file đã được sửa bởi Cowork — chỉ cần stage + commit)
+git add linux-onboard/file-descriptor-deep-dive.md
+git commit -m "docs(linux): add real lab output for FD experiments 5-6 (strace, CLOEXEC)
+
+- Section 1.4: replace placeholder with real strace output from huyvl-lab-fd
+  (PID 558, socket:[20882], accept4 with SOCK_CLOEXEC, FD reuse demo)
+- Section 1.9: replace placeholder strace lifecycle output
+- Section 1.10: rewrite Guided Exercise with real experiment output
+  (Part A: FD leak without CLOEXEC, Part B: kernel closes FD with CLOEXEC)
+- Add clean environment verification step (lesson from experiment 5 failure)
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+
+# 3. Push
+git push -u origin feat/fd-lab-strace-cloexec
+
+# 4. Tạo PR
+gh pr create --base master --title "docs(linux): add real lab output for FD experiments 5-6" --body "## Summary
+- Replace placeholder output in sections 1.4, 1.9, 1.10 with real terminal output from huyvl-lab-fd
+- Section 1.4: strace showing accept4() with SOCK_CLOEXEC, FD reuse via lowest-available-number
+- Section 1.9: strace socket lifecycle with SOCK_CLOEXEC flags
+- Section 1.10: complete rewrite of Guided Exercise — Part A proves FD leak, Part B proves CLOEXEC prevents it
 
 ## Test plan
 - [ ] Markdown renders correctly on GitHub
-- [ ] All 11 reference URLs accessible
-- [ ] Lab output matches real machine output"
-
-# Sau khi merge PR:
-git checkout master
-git pull origin master
+- [ ] Lab output consistent across sections (PID 527/558/577, huyvl-lab-fd hostname)
+- [ ] Cross-reference: section 1.10 Key Topic correctly links to section 1.4 strace observation"
 ```
 
 ### Bài học rút ra từ session này
 
-1. **HAProxy source code verification** là bắt buộc khi claim về internal behavior — documentation và source code có thể khác nhau (hybrid ET/LT vs "LT by default")
-2. **"trên mọi X" claims** cần verify cẩn thận — thực tế thường là conditional, có fallback
+1. **Kiểm tra môi trường sạch trước mỗi thí nghiệm** — FD 3 còn sót từ thí nghiệm 3 gây experiment 5 thất bại (Python server nhận FD 4 thay vì FD 3)
+2. **`dup2(fd, fd)` khi source == target** là POSIX no-op, nhưng `os.close(fd)` ngay sau sẽ đóng FD cần giữ → phải guard bằng `if fd != target`
+3. **Sandbox lock file** vẫn là blocker — cần user xóa trên local trước khi git operations
 
 ---
 
 ## Lịch sử sessions trước
 
+### Session 2026-04-02
+
+**Branch:** `fix/fd-doc-audit-corrections` (clean — commit `6ecfb07`)
+**Đã hoàn thành:** Full 6-phase audit FD doc (13 claims fact-checked, 2 corrected: HAProxy ET/LT, HAProxy CLOEXEC conditional), verify 11 URLs, replace lab output placeholder.
+
 ### Session 2026-03-30 (session 2)
 
 **Branch:** `master` (dirty — audit changes)
-**Đã hoàn thành:** Audit HAProxy structure + Part 1, tích hợp Version Evolution Tracker vào Phụ lục A, sửa Knowledge Dependency Graph (4 edges), thu gọn root README, đồng bộ haproxy-series-state.md, cập nhật CLAUDE.md Rule 1, thêm Checklist F.
+**Đã hoàn thành:** Audit HAProxy structure + Part 1, tích hợp Version Evolution Tracker vào Phụ lục A, sửa Knowledge Dependency Graph (4 edges), thu gọn root README.
 
 ### Session 2026-03-29
 


### PR DESCRIPTION
## Summary
- Replace placeholder output in sections 1.4, 1.9, 1.10 with real terminal output from huyvl-lab-fd
- Section 1.4: strace showing accept4() with SOCK_CLOEXEC, FD reuse via lowest-available-number
- Section 1.9: strace socket lifecycle with SOCK_CLOEXEC flags
- Section 1.10: complete rewrite of Guided Exercise — Part A proves FD leak, Part B proves CLOEXEC prevents it

## Test plan
- [ ] Markdown renders correctly on GitHub
- [ ] Lab output consistent across sections (PID 527/558/577, huyvl-lab-fd hostname)
- [ ] Cross-reference: section 1.10 Key Topic correctly links to section 1.4 strace observation